### PR TITLE
Added Procfile for Heroku deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.env

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: node app.js


### PR DESCRIPTION
This edit to (and creation of) the `Procfile` is necessary for deployment to Heroku. The specific edit, commit a59cfea, will make the heroku app a worker instead of a web app so that it is good for its duty as a bot.